### PR TITLE
ci: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          for i in 1 2 3 4 5; do
+            gh pr merge --auto --squash "$PR_URL" && exit 0
+            echo "enablePullRequestAutoMerge race (attempt $i) — retrying in 15s…"
+            sleep 15
+          done
+          exit 1
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependabot-automerge.yml` to automatically enable GitHub's native auto-merge on Dependabot PRs
- Scope: patch + minor updates only — majors remain manual for breaking-change review
- Uses `dependabot/fetch-metadata` (SHA-pinned to v2.3.0) to gate on update type
- Merge method is `--squash` to match the repo's linear-history ruleset
- Includes a 5-attempt retry loop to handle the merge-state race condition that would otherwise cause a single-shot `gh pr merge --auto` to silently fail

## Note

The repo's required status check in the ruleset (\`"Build, unit & e2e tests"\`) does not currently match the CI job name (\`"Build with Gradle"\`). Auto-merge will queue correctly but may not release until that mismatch is resolved — tracked separately.

## Test plan

- [ ] Merge this PR and verify a subsequent Dependabot patch/minor PR auto-merges after CI passes
- [ ] Verify a Dependabot major-version PR is NOT auto-merged